### PR TITLE
feat: Implement user registration endpoint (REQ-001)

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,2 +1,5 @@
 """API routes package."""
 
+from app.api.auth import router as auth_router
+
+__all__ = ["auth_router"]

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,0 +1,43 @@
+"""Authentication API endpoints."""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.database import get_db
+from app.schemas.user import UserCreate, UserResponse
+from app.services.auth import create_user, get_user_by_username
+
+
+router = APIRouter(prefix="/api/auth", tags=["auth"])
+
+
+@router.post("/register", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
+async def register(
+    user_data: UserCreate,
+    db: AsyncSession = Depends(get_db),
+) -> UserResponse:
+    """Register a new user.
+
+    Args:
+        user_data: User registration data (username, password).
+        db: Database session.
+
+    Returns:
+        Created user data (id, username).
+
+    Raises:
+        HTTPException: 409 if username already exists.
+        HTTPException: 422 for invalid input.
+    """
+    # Check if username already exists
+    existing_user = await get_user_by_username(db, user_data.username)
+    if existing_user:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Username already registered",
+        )
+
+    # Create new user
+    user = await create_user(db, user_data)
+    return UserResponse.model_validate(user)
+

--- a/backend/app/core/__init__.py
+++ b/backend/app/core/__init__.py
@@ -1,0 +1,5 @@
+"""Core application package."""
+
+from app.core.security import hash_password, verify_password
+
+__all__ = ["hash_password", "verify_password"]

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,0 +1,34 @@
+"""Security utilities for password hashing."""
+
+import bcrypt
+
+
+def hash_password(password: str) -> str:
+    """Hash a password using bcrypt.
+
+    Args:
+        password: Plain text password to hash.
+
+    Returns:
+        Hashed password string.
+    """
+    password_bytes = password.encode("utf-8")
+    salt = bcrypt.gensalt()
+    hashed = bcrypt.hashpw(password_bytes, salt)
+    return hashed.decode("utf-8")
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """Verify a plain password against a hashed password.
+
+    Args:
+        plain_password: Plain text password to verify.
+        hashed_password: Hashed password to compare against.
+
+    Returns:
+        True if password matches, False otherwise.
+    """
+    password_bytes = plain_password.encode("utf-8")
+    hashed_bytes = hashed_password.encode("utf-8")
+    return bcrypt.checkpw(password_bytes, hashed_bytes)
+

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ from typing import AsyncGenerator
 
 from fastapi import FastAPI
 
+from app.api.auth import router as auth_router
 from app.db.database import check_database_connection
 
 # Configure logging
@@ -43,6 +44,10 @@ app = FastAPI(
     version="0.1.0",
     lifespan=lifespan,
 )
+
+
+# Include routers
+app.include_router(auth_router)
 
 
 @app.get("/health")

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,2 +1,5 @@
 """Pydantic schemas package."""
 
+from app.schemas.user import UserCreate, UserResponse
+
+__all__ = ["UserCreate", "UserResponse"]

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,0 +1,20 @@
+"""User schemas for request/response validation."""
+
+from pydantic import BaseModel, Field
+
+
+class UserCreate(BaseModel):
+    """Schema for user registration request."""
+
+    username: str = Field(..., min_length=3, max_length=50, description="Username for the new user")
+    password: str = Field(..., min_length=1, description="Password for the new user")
+
+
+class UserResponse(BaseModel):
+    """Schema for user response (without password)."""
+
+    id: int = Field(..., description="User ID")
+    username: str = Field(..., description="Username")
+
+    model_config = {"from_attributes": True}
+

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,0 +1,2 @@
+"""Services package."""
+

--- a/backend/tests/test_auth_api.py
+++ b/backend/tests/test_auth_api.py
@@ -1,0 +1,133 @@
+"""Tests for authentication API endpoints."""
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.db.database import Base, get_db
+from app.main import app
+
+
+# Use async in-memory SQLite for testing
+TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+
+engine = create_async_engine(
+    TEST_DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+TestAsyncSessionLocal = async_sessionmaker(
+    bind=engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+)
+
+
+async def override_get_db():
+    """Override get_db dependency for testing."""
+    async with TestAsyncSessionLocal() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+
+
+# Override the dependency
+app.dependency_overrides[get_db] = override_get_db
+
+
+@pytest_asyncio.fixture(scope="function", autouse=True)
+async def setup_database():
+    """Create tables before each test and drop after."""
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest_asyncio.fixture
+async def client():
+    """Async test client fixture."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+class TestRegistration:
+    """Test cases for user registration endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_register_success(self, client):
+        """Test successful user registration."""
+        response = await client.post(
+            "/api/auth/register",
+            json={"username": "testuser", "password": "testpass123"},
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert "id" in data
+        assert data["username"] == "testuser"
+        assert "password" not in data
+        assert "hashed_password" not in data
+
+    @pytest.mark.asyncio
+    async def test_register_duplicate_username(self, client):
+        """Test registration with duplicate username returns 409."""
+        # First registration
+        response1 = await client.post(
+            "/api/auth/register",
+            json={"username": "duplicateuser", "password": "pass1"},
+        )
+        assert response1.status_code == 201
+
+        # Second registration with same username
+        response2 = await client.post(
+            "/api/auth/register",
+            json={"username": "duplicateuser", "password": "pass2"},
+        )
+        assert response2.status_code == 409
+        assert "already registered" in response2.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_register_invalid_input_missing_username(self, client):
+        """Test registration with missing username returns 422."""
+        response = await client.post(
+            "/api/auth/register",
+            json={"password": "testpass123"},
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_register_invalid_input_missing_password(self, client):
+        """Test registration with missing password returns 422."""
+        response = await client.post(
+            "/api/auth/register",
+            json={"username": "testuser"},
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_register_username_too_short(self, client):
+        """Test registration with username too short returns 422."""
+        response = await client.post(
+            "/api/auth/register",
+            json={"username": "ab", "password": "testpass123"},
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_register_username_too_long(self, client):
+        """Test registration with username too long returns 422."""
+        long_username = "a" * 51
+        response = await client.post(
+            "/api/auth/register",
+            json={"username": long_username, "password": "testpass123"},
+        )
+        assert response.status_code == 422
+

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -1,0 +1,72 @@
+"""Tests for security utilities."""
+
+import pytest
+
+from app.core.security import hash_password, verify_password
+
+
+class TestPasswordHashing:
+    """Test cases for password hashing functions."""
+
+    def test_hash_password_returns_hashed_string(self):
+        """Test that hash_password returns a hashed string."""
+        password = "mysecretpassword"
+        hashed = hash_password(password)
+        
+        assert hashed is not None
+        assert isinstance(hashed, str)
+        assert hashed != password
+        assert len(hashed) > 0
+
+    def test_hash_password_uses_bcrypt(self):
+        """Test that hash_password uses bcrypt format."""
+        password = "testpassword"
+        hashed = hash_password(password)
+        
+        # Bcrypt hashes start with $2b$ or $2a$ or $2y$
+        assert hashed.startswith("$2")
+
+    def test_hash_password_different_for_same_password(self):
+        """Test that hashing same password twice produces different hashes."""
+        password = "samepassword"
+        hash1 = hash_password(password)
+        hash2 = hash_password(password)
+        
+        # Due to salting, hashes should be different
+        assert hash1 != hash2
+
+    def test_verify_password_correct(self):
+        """Test verify_password with correct password."""
+        password = "correctpassword"
+        hashed = hash_password(password)
+        
+        assert verify_password(password, hashed) is True
+
+    def test_verify_password_incorrect(self):
+        """Test verify_password with incorrect password."""
+        password = "correctpassword"
+        hashed = hash_password(password)
+        
+        assert verify_password("wrongpassword", hashed) is False
+
+    def test_verify_password_empty_password(self):
+        """Test verify_password with empty password."""
+        password = "realpassword"
+        hashed = hash_password(password)
+        
+        assert verify_password("", hashed) is False
+
+    def test_hash_password_handles_special_characters(self):
+        """Test hashing password with special characters."""
+        password = "p@$$w0rd!#$%^&*()"
+        hashed = hash_password(password)
+        
+        assert verify_password(password, hashed) is True
+
+    def test_hash_password_handles_unicode(self):
+        """Test hashing password with unicode characters."""
+        password = "пароль密码🔐"
+        hashed = hash_password(password)
+        
+        assert verify_password(password, hashed) is True
+


### PR DESCRIPTION
# Summary
- Add user registration endpoint with password hashing and validation
- Create schemas, services, and API layer for authentication
- Implement bcrypt password hashing with proper security practices

## Related Work
- Closes: #10
- Epic: #1 (User Authentication)
- Requirements: REQ-001
- Depends on: PR #30 (Issue #9 - User model)

## What Changed
- `backend/app/api/auth.py`: POST /api/auth/register endpoint with 409 for duplicates, 422 for validation
- `backend/app/schemas/user.py`: UserCreate (username, password) and UserResponse (id, username) schemas
- `backend/app/core/security.py`: bcrypt hash_password and verify_password functions
- `backend/app/services/auth.py`: create_user and get_user_by_username service functions
- `backend/app/main.py`: Include auth router
- `backend/tests/test_auth_api.py`: Integration tests for registration endpoint
- `backend/tests/test_security.py`: Unit tests for password hashing

## How To Test
```bash
cd backend
source venv/bin/activate
pip install -r requirements.txt

# Run all tests
python -m pytest tests/ -v

# Run only auth API tests
python -m pytest tests/test_auth_api.py -v

# Run only security tests
python -m pytest tests/test_security.py -v
```

## Acceptance Criteria
- [x] Endpoint accepts username + password
- [x] Password hashed with bcrypt before storage
- [x] Returns user data (without password)
- [x] Returns 409 if username exists
- [x] Returns 422 for invalid input

## Risk & Rollback
- Risk: low — New endpoint, no changes to existing functionality
- Rollback: revert this PR

## Notes
- Uses bcrypt directly instead of passlib due to compatibility issues with latest bcrypt version
- Tests use async SQLite for proper async session testing
